### PR TITLE
Add scaleUxToDp for DIP scaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12788,49 +12788,6 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT"
     },
-    "node_modules/node-notifier": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
-      "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
-      }
-    },
-    "node_modules/node-notifier/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/node-notifier/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/node-notifier/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -15008,6 +14965,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-native-tscodegen-types/node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/react-native-tscodegen-types/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -15610,6 +15576,19 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-tscodegen-types/node_modules/node-notifier": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.5.tgz",
+      "integrity": "sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "node_modules/react-native-tscodegen-types/node_modules/normalize-path": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {Grid} from './config';
 import {Pressable, ScrollView, StyleSheet, Text, View} from 'react-native';
 import {TVFocusGuideView} from '@amazon-devices/react-native-kepler';
 import {SCREEN_DIMENSION} from './constants';
+import {scaleUxToDp} from './utils/PixelUtils';
 import {MOVIES_DATA} from './carousel-demo/Data/MoviesData';
 import {HorizontalScrollable} from './carousel-demo/components/HorizontalScrollable';
 import {VerticalScrollable} from './carousel-demo/components/VerticalScrollable';
@@ -132,16 +133,16 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   sidebar: {
-    width: 75,
+    width: scaleUxToDp(150),
     flexGrow: 0,
     flexShrink: 0,
     height: '100%',
     backgroundColor: '#1b1f24',
-    paddingTop: 12,
+    paddingTop: scaleUxToDp(24),
   },
   tab: {
-    paddingVertical: 6,
-    paddingHorizontal: 7,
+    paddingVertical: scaleUxToDp(12),
+    paddingHorizontal: scaleUxToDp(14),
   },
   tabActive: {
     backgroundColor: '#33414f',
@@ -151,26 +152,26 @@ const styles = StyleSheet.create({
   },
   tabLabel: {
     color: '#ffffff',
-    fontSize: 8,
+    fontSize: scaleUxToDp(16),
   },
   content: {
     flex: 1,
     height: '100%',
     overflow: 'hidden',
-    padding: 12,
+    padding: scaleUxToDp(24),
   },
   contentInner: {
     flex: 1,
   },
   descriptionLabel: {
     color: '#e6edf3',
-    fontSize: 8,
-    marginBottom: 3,
+    fontSize: scaleUxToDp(15),
+    marginBottom: scaleUxToDp(6),
   },
   indicatorLabel: {
     color: '#9fb3c8',
-    fontSize: 7,
+    fontSize: scaleUxToDp(13),
     fontFamily: 'monospace',
-    marginBottom: 4,
+    marginBottom: scaleUxToDp(8),
   },
 });

--- a/src/carousel-demo/components/HeterogeneousScrollable.tsx
+++ b/src/carousel-demo/components/HeterogeneousScrollable.tsx
@@ -13,6 +13,7 @@ import {useCallback, useMemo, useState} from 'react';
 import React from 'react';
 import {ItemType, ScrollableProps} from '../Types';
 import {CAROUSEL_STYLE} from './Style';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 // Defined at module scope so they are stable component types across renders.
 // These retain focus state because it drives the itemFocusContainer style.
@@ -81,8 +82,8 @@ const getSelectedItemOffset = (_info: CarouselRenderInfo): ShiftFactor => ({
 });
 
 const ITEM_STYLE: CarouselItemStyleProps = {
-  itemPadding: 20,
-  itemPaddingOnSelection: 20,
+  itemPadding: scaleUxToDp(40),
+  itemPaddingOnSelection: scaleUxToDp(40),
   pressedItemScaleFactor: 0.9,
   selectedItemScaleFactor: SELECTED_ITEM_SCALE_FACTOR,
   getSelectedItemOffset,
@@ -97,11 +98,11 @@ const ANIMATION_DURATION: AnimationDurationProps = {
 const SELECTION_BORDER: SelectionBorderProps = {
   borderStrategy: 'inset',
   borderColor: 'white',
-  borderWidth: 2,
-  borderRadius: 4,
-  borderStrokeRadius: 2,
+  borderWidth: scaleUxToDp(4),
+  borderRadius: scaleUxToDp(8),
+  borderStrokeRadius: scaleUxToDp(4),
   borderStrokeColor: 'black',
-  borderStrokeWidth: 1,
+  borderStrokeWidth: scaleUxToDp(2),
 };
 
 /**

--- a/src/carousel-demo/components/HorizontalScrollable.tsx
+++ b/src/carousel-demo/components/HorizontalScrollable.tsx
@@ -15,6 +15,7 @@ import {Ref, forwardRef, useImperativeHandle, useRef} from 'react';
 
 import {ItemType, ScrollableProps} from '../Types';
 import {CAROUSEL_STYLE} from './Style';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 // Module scope so ItemView is a stable component type; defining it inside the
 // parent would remount every item on each render.
@@ -48,8 +49,8 @@ const getSelectedItemOffset = (_info: CarouselRenderInfo): ShiftFactor => ({
 });
 
 const ITEM_STYLE: CarouselItemStyleProps = {
-  itemPadding: 10,
-  itemPaddingOnSelection: 10,
+  itemPadding: scaleUxToDp(20),
+  itemPaddingOnSelection: scaleUxToDp(20),
   pressedItemScaleFactor: 0.9,
   selectedItemScaleFactor: FOCUSED_ITEM_SCALE_FACTOR,
   getSelectedItemOffset,

--- a/src/carousel-demo/components/PinnedScrollable.tsx
+++ b/src/carousel-demo/components/PinnedScrollable.tsx
@@ -15,6 +15,7 @@ import {
 } from '@amazon-devices/vega-carousel';
 import {Ref, forwardRef, useImperativeHandle, useRef} from 'react';
 import {ItemType, ScrollableProps} from '../Types';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 type PinOffset = `${number}%`;
 
@@ -45,8 +46,8 @@ const renderPoster = ({item}: CarouselRenderInfo<ItemType>) => (
 );
 
 const SWIMLANE_ITEM_STYLE: CarouselItemStyleProps = {
-  itemPadding: 10,
-  itemPaddingOnSelection: 10,
+  itemPadding: scaleUxToDp(20),
+  itemPaddingOnSelection: scaleUxToDp(20),
   selectedItemScaleFactor: 1.0,
   pressedItemScaleFactor: 1.0,
 };
@@ -58,8 +59,8 @@ const SWIMLANE_ANIMATION_DURATION: AnimationDurationProps = {
 const SWIMLANE_SELECTION_BORDER: SelectionBorderProps = {
   borderStrategy: 'outset',
   borderColor: '#00FF00',
-  borderWidth: 2,
-  borderRadius: 4,
+  borderWidth: scaleUxToDp(3),
+  borderRadius: scaleUxToDp(8),
 };
 
 const outerKeyProvider = (info: CarouselRenderInfo) => `swimlane-${info.index}`;
@@ -176,11 +177,20 @@ export const PinnedScrollable = forwardRef(
 
 const styles = StyleSheet.create({
   container: {width: '100%', height: '100%', backgroundColor: '#000'},
-  header: {color: 'lime', padding: 3, fontSize: 7},
+  header: {color: 'lime', padding: scaleUxToDp(5), fontSize: scaleUxToDp(14)},
   outerCarousel: {height: '100%', width: '100%'},
-  swimlane: {height: 173, width: '100%', borderWidth: 1, borderColor: 'lime'},
-  swimlaneLabel: {color: 'white', marginLeft: 10, marginBottom: 3},
-  swimlaneCarousel: {width: '100%', height: 155},
-  poster: {width: 100, height: 150},
+  swimlane: {
+    height: scaleUxToDp(345),
+    width: '100%',
+    borderWidth: scaleUxToDp(2),
+    borderColor: 'lime',
+  },
+  swimlaneLabel: {
+    color: 'white',
+    marginLeft: scaleUxToDp(20),
+    marginBottom: scaleUxToDp(5),
+  },
+  swimlaneCarousel: {width: '100%', height: scaleUxToDp(310)},
+  poster: {width: scaleUxToDp(200), height: scaleUxToDp(300)},
   posterImage: {width: '100%', height: '100%', resizeMode: 'cover'},
 });

--- a/src/carousel-demo/components/PinnedVertical.tsx
+++ b/src/carousel-demo/components/PinnedVertical.tsx
@@ -26,6 +26,7 @@ import {
 } from '@amazon-devices/vega-carousel';
 import {Button} from '@amazon-devices/kepler-ui-components';
 import {ItemType, ScrollableProps} from '../Types';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 const INITIAL_START_INDEX = 5;
 const PIN = '44%';
@@ -42,8 +43,8 @@ const renderPoster = ({item}: CarouselRenderInfo<ItemType>) => (
 );
 
 const ITEM_STYLE: CarouselItemStyleProps = {
-  itemPadding: 10,
-  itemPaddingOnSelection: 10,
+  itemPadding: scaleUxToDp(20),
+  itemPaddingOnSelection: scaleUxToDp(20),
   selectedItemScaleFactor: 1.0,
   pressedItemScaleFactor: 1.0,
 };
@@ -53,8 +54,8 @@ const ANIMATION_DURATION: AnimationDurationProps = {itemScrollDuration: 0.2};
 const SELECTION_BORDER: SelectionBorderProps = {
   borderStrategy: 'outset',
   borderColor: '#00FFFF',
-  borderWidth: 2,
-  borderRadius: 4,
+  borderWidth: scaleUxToDp(3),
+  borderRadius: scaleUxToDp(8),
 };
 
 export const PinnedVertical = forwardRef(
@@ -120,11 +121,15 @@ export const PinnedVertical = forwardRef(
 const styles = StyleSheet.create({
   container: {width: '100%', height: '100%', backgroundColor: '#000'},
   row: {flex: 1, flexDirection: 'row'},
-  carousel: {width: 100, height: '100%'},
-  poster: {width: 100, height: 115},
+  carousel: {width: scaleUxToDp(200), height: '100%'},
+  poster: {width: scaleUxToDp(200), height: scaleUxToDp(230)},
   posterImage: {width: '100%', height: '100%', resizeMode: 'cover'},
-  controls: {marginLeft: 20, justifyContent: 'center', flex: 1},
-  title: {color: 'cyan', fontSize: 7, marginBottom: 10},
-  scrollToLabel: {color: 'white', marginBottom: 5},
-  button: {marginBottom: 5},
+  controls: {marginLeft: scaleUxToDp(40), justifyContent: 'center', flex: 1},
+  title: {
+    color: 'cyan',
+    fontSize: scaleUxToDp(14),
+    marginBottom: scaleUxToDp(20),
+  },
+  scrollToLabel: {color: 'white', marginBottom: scaleUxToDp(10)},
+  button: {marginBottom: scaleUxToDp(10)},
 });

--- a/src/carousel-demo/components/Style.ts
+++ b/src/carousel-demo/components/Style.ts
@@ -1,4 +1,5 @@
 import {StyleSheet} from 'react-native';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 export const CAROUSEL_STYLE = StyleSheet.create({
   container: {
@@ -14,36 +15,36 @@ export const CAROUSEL_STYLE = StyleSheet.create({
     resizeMode: 'cover',
   },
   itemHorizontalContainer: {
-    width: 125,
+    width: scaleUxToDp(250),
     height: '100%',
   },
   itemVerticalContainer: {
     width: '100%',
-    height: 210,
+    height: scaleUxToDp(420),
   },
   itemContainerType1: {
-    height: 210,
-    width: 100,
+    height: scaleUxToDp(420),
+    width: scaleUxToDp(200),
     justifyContent: 'center',
     alignContent: 'center',
   },
   itemContainerType2: {
-    height: 210,
-    width: 250,
+    height: scaleUxToDp(420),
+    width: scaleUxToDp(500),
     justifyContent: 'center',
     alignContent: 'center',
   },
   itemFocusContainer: {
-    borderWidth: 2,
+    borderWidth: scaleUxToDp(4),
     borderColor: 'white',
   },
   horizontalCarouselContainerStyle: {
     width: '100%',
-    height: 210,
+    height: scaleUxToDp(420),
   },
   verticalCarouselContainerStyle: {
     height: '100%',
-    width: 125,
+    width: scaleUxToDp(250),
     justifyContent: 'center',
   },
 });

--- a/src/carousel-demo/components/VerticalScrollable.tsx
+++ b/src/carousel-demo/components/VerticalScrollable.tsx
@@ -13,6 +13,7 @@ import {useCallback, useMemo} from 'react';
 import React from 'react';
 import {ItemType, ScrollableProps} from '../Types';
 import {CAROUSEL_STYLE} from './Style';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 // Module scope so ItemView is a stable component type; defining it inside the
 // parent would remount every item on each render.
@@ -44,8 +45,8 @@ const getSelectedItemOffset = (
 ): ShiftFactor | undefined => undefined; // Use the default offset.
 
 const ITEM_STYLE: CarouselItemStyleProps = {
-  itemPadding: 5,
-  itemPaddingOnSelection: 10,
+  itemPadding: scaleUxToDp(10),
+  itemPaddingOnSelection: scaleUxToDp(20),
   pressedItemScaleFactor: 0.8,
   selectedItemScaleFactor: 1,
   getSelectedItemOffset,
@@ -60,11 +61,11 @@ const ANIMATION_DURATION: AnimationDurationProps = {
 const SELECTION_BORDER: SelectionBorderProps = {
   borderStrategy: 'outset',
   borderColor: '#FFC107',
-  borderWidth: 3,
-  borderRadius: 5,
-  borderStrokeRadius: 3,
+  borderWidth: scaleUxToDp(5),
+  borderRadius: scaleUxToDp(10),
+  borderStrokeRadius: scaleUxToDp(5),
   borderStrokeColor: 'yellow',
-  borderStrokeWidth: 1,
+  borderStrokeWidth: scaleUxToDp(2),
 };
 
 /**

--- a/src/carousel-demo/screens/Styles.ts
+++ b/src/carousel-demo/screens/Styles.ts
@@ -1,4 +1,5 @@
 import {StyleSheet} from 'react-native';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 export const styles = StyleSheet.create({
   container: {
@@ -10,10 +11,10 @@ export const styles = StyleSheet.create({
   },
   carousel: {
     height: '50%',
-    padding: 50,
+    padding: scaleUxToDp(100),
     width: '100%',
   },
   gap: {
-    paddingTop: 100,
+    paddingTop: scaleUxToDp(200),
   },
 });

--- a/src/components/Carousel/CarouselCardRow.tsx
+++ b/src/components/Carousel/CarouselCardRow.tsx
@@ -23,6 +23,7 @@ import {
   cardKeyExtractor,
   checkIfCardRowDataSame,
 } from '../../utils/listUtils';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 // Module-scope handlers/objects: stable references shared across all rows.
 const notifyDataError = (_error: CarouselDataError): boolean => false; // Don't retry
@@ -38,8 +39,8 @@ const onSelectionChanged = (event: CarouselSelectionChangeEvent): void => {
 };
 
 const ITEM_STYLE: CarouselItemStyleProps = {
-  itemPadding: 10,
-  itemPaddingOnSelection: 10,
+  itemPadding: scaleUxToDp(20),
+  itemPaddingOnSelection: scaleUxToDp(20),
   pressedItemScaleFactor: 0.8,
   selectedItemScaleFactor: 1,
   getSelectedItemOffset,

--- a/src/components/Carousel/CarouselGrid.tsx
+++ b/src/components/Carousel/CarouselGrid.tsx
@@ -15,6 +15,7 @@ import {RowData} from '../../types';
 import {buildRowRenderer, rowKeyExtractor} from '../../utils/listUtils';
 import {store} from '../../store';
 import {Provider} from 'react-redux';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 // The grid renders a fixed module-level dataset (ROW_DATA), so its renderer and
 // data adapter can live at module scope rather than being memoized per instance.
@@ -46,8 +47,8 @@ const CONTAINER_STYLE = {
 };
 
 const ITEM_STYLE: CarouselItemStyleProps = {
-  itemPadding: 10,
-  itemPaddingOnSelection: 10,
+  itemPadding: scaleUxToDp(20),
+  itemPaddingOnSelection: scaleUxToDp(20),
   pressedItemScaleFactor: 1,
   selectedItemScaleFactor: 1,
   getSelectedItemOffset,

--- a/src/config/layout/cardConfig.ts
+++ b/src/config/layout/cardConfig.ts
@@ -1,5 +1,6 @@
 import {TextStyle} from 'react-native';
 import {CardType, ImageResolutions} from '../../types';
+import {scaleUxToDp} from '../../utils/PixelUtils';
 
 type CardConfig = Record<
   CardType,
@@ -14,11 +15,6 @@ type CardConfig = Record<
       WIDTH: number;
       BORDER_RADIUS: number;
       RESOLUTION: keyof typeof ImageResolutions;
-      // Per-card horizontal gap, applied as marginRight on the card itself.
-      // Kept at 0 for the V2 vega-carousel path, which controls spacing via
-      // itemStyle.itemPadding / itemPaddingOnSelection instead. The FlashList
-      // path has no such item padding, so it relies on this GAP for spacing —
-      // change it here if you need gaps in the FlashList grid.
       GAP: number;
     };
     ROW_GAP: number;
@@ -28,47 +24,47 @@ type CardConfig = Record<
 export const CARD_CONFIG: CardConfig = {
   HERO: {
     TITLE: {
-      HEIGHT: 30,
-      FONT_SIZE: 25,
+      HEIGHT: scaleUxToDp(60),
+      FONT_SIZE: scaleUxToDp(50),
       FONT_WEIGHT: '700',
     },
     CARD: {
-      HEIGHT: 200,
-      WIDTH: 350,
-      BORDER_RADIUS: 15,
+      HEIGHT: scaleUxToDp(400),
+      WIDTH: scaleUxToDp(700),
+      BORDER_RADIUS: scaleUxToDp(30),
       RESOLUTION: '720',
       GAP: 0,
     },
-    ROW_GAP: 50,
+    ROW_GAP: scaleUxToDp(100),
   },
   VERTICAL: {
     TITLE: {
-      HEIGHT: 25,
-      FONT_SIZE: 18,
+      HEIGHT: scaleUxToDp(50),
+      FONT_SIZE: scaleUxToDp(35),
       FONT_WEIGHT: '300',
     },
     CARD: {
-      HEIGHT: 200,
-      WIDTH: 125,
-      BORDER_RADIUS: 10,
+      HEIGHT: scaleUxToDp(400),
+      WIDTH: scaleUxToDp(250),
+      BORDER_RADIUS: scaleUxToDp(20),
       RESOLUTION: '260',
       GAP: 0,
     },
-    ROW_GAP: 15,
+    ROW_GAP: scaleUxToDp(30),
   },
   REGULAR: {
     TITLE: {
-      HEIGHT: 25,
-      FONT_SIZE: 18,
+      HEIGHT: scaleUxToDp(50),
+      FONT_SIZE: scaleUxToDp(35),
       FONT_WEIGHT: '300',
     },
     CARD: {
-      HEIGHT: 88,
-      WIDTH: 150,
-      BORDER_RADIUS: 8,
+      HEIGHT: scaleUxToDp(175),
+      WIDTH: scaleUxToDp(300),
+      BORDER_RADIUS: scaleUxToDp(15),
       RESOLUTION: '400',
       GAP: 0,
     },
-    ROW_GAP: 15,
+    ROW_GAP: scaleUxToDp(30),
   },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,8 @@
 import {Dimensions} from 'react-native';
+import {scaleUxToDp} from './utils/PixelUtils';
 
 export const SCREEN_DIMENSION = Dimensions.get('window');
 
 export const DEFAULT_IMAGE_RESOLUTION = '300';
 
-export const PAGE_PADDING = 25;
+export const PAGE_PADDING = scaleUxToDp(50);

--- a/src/utils/PixelUtils.ts
+++ b/src/utils/PixelUtils.ts
@@ -1,0 +1,10 @@
+import {Dimensions, PixelRatio} from 'react-native';
+
+const SCREEN_DP = Dimensions.get('window');
+const REFERENCE_HEIGHT = 1080;
+
+export const scaleUxToDp = (
+  uxUnit: number,
+  referenceHeight: number = REFERENCE_HEIGHT,
+): number =>
+  PixelRatio.roundToNearestPixel(uxUnit * (SCREEN_DP.height / referenceHeight));


### PR DESCRIPTION
## Summary
- Add `PixelUtils.ts` with `scaleUxToDp()` to properly scale 1080p UX values to dp
- Replace hardcoded halved pixel values with `scaleUxToDp(original_1080p_value)` across all components
- Uses `PixelRatio.roundToNearestPixel` for correct pixel-boundary alignment
- Future-proof across different device resolutions

## Test plan
- [x] App launches on Fire TV Stick with v4 runtime
- [x] Grid layout renders at correct proportions
- [x] Carousel demo tabs display correctly
- [x] Confirmed SCREEN_DP reports 960x540, scale: 2

## Related
- CR-290095407 (approved)
- VEGATV-111301